### PR TITLE
CMake: SET CMP0077 NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(SDL_audiolib
     DESCRIPTION "An audio decoding, resampling and mixing library."
 )
 set(AULIB_VERSION 0x000000)
+cmake_policy(SET CMP0077 NEW)
 
 option(
     USE_RESAMP_SRC


### PR DESCRIPTION
This allows an easier integration via FetchContent, so that the options can simply be set as `set(USE_DEC_MODPLUG OFF)`.
The policy is available since CMake 3.13