### PR TITLE
CMake: Remove headers from add_library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,8 +294,6 @@ link_directories(
 add_library(
     SDL_audiolib
 
-    ${PUBLIC_HEADERS}
-    ${PUBLIC_HEADERS_AULIB_DIR}
     ${AULIB_SOURCES}
 
     src/Buffer.h


### PR DESCRIPTION
Generated headers may not yet be available when calling `add_library`.

Regardless, `add_library` should only be provided with sources, not headers.

Fixes #2