### PR TITLE
CMake: SET CMP0069 NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(SDL_audiolib
     DESCRIPTION "An audio decoding, resampling and mixing library."
 )
 set(AULIB_VERSION 0x000000)
+
+cmake_policy(SET CMP0069 NEW)
 cmake_policy(SET CMP0077 NEW)
 
 option(


### PR DESCRIPTION
Allows using CMake's built-in LTO support.

Fixes the following warning:

```
CMake Warning (dev) at SDL_audiolib/CMakeLists.txt:298 (add_library):
  Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
  enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  INTERPROCEDURAL_OPTIMIZATION property will be ignored for target
  'SDL_audiolib'.
```