### PR TITLE
CMake: Cleanup policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,15 @@ project(SDL_audiolib
 )
 set(AULIB_VERSION 0x000000)
 
-cmake_policy(SET CMP0069 NEW)
-cmake_policy(SET CMP0077 NEW)
+if(POLICY CMP0069)
+    cmake_policy(SET CMP0069 NEW)
+endif()
+if(POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+endif()
+if(POLICY CMP0111)
+    cmake_policy(SET CMP0111 NEW)
+endif()
 
 option(
     USE_SDL1
@@ -136,7 +143,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-cmake_policy(SET CMP0063 NEW)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)


### PR DESCRIPTION
1. Check that the policy exists before setting it.
2. Add CMP0111 for early failure of `find_package` in case of a broken cmake config (as seen on mingw).
3. Remove CMP0063, it is already covered by the minimum CMake version (3.8 vs 3.3)