### PR TITLE
Fix assertion failure (crash) at exit

### DIFF
--- a/src/aulib.cpp
+++ b/src/aulib.cpp
@@ -123,6 +123,11 @@ void Aulib::quit()
             stream->stop();
         }
     }
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    SDL_CloseAudioDevice(Stream_priv::fDeviceId);
+#else
+    SDL_CloseAudio();
+#endif
     SDL_QuitSubSystem(SDL_INIT_AUDIO);
     Stream_priv::fSampleConverter = nullptr;
     gInitialized = false;


### PR DESCRIPTION
Fixes the following assertion failure at exit:

> src/stream_p.cpp:89: static void Aulib::Stream_priv::fSdlCallbackImpl(void*, Uint8*, int): Assertion `Stream_priv::fSampleConverter != nullptr' failed.

Fixes #19