### PR TITLE
Fix clang-8 compatibility

### DIFF
--- a/include/Aulib/Decoder.h
+++ b/include/Aulib/Decoder.h
@@ -84,7 +84,7 @@ template <class... Decoders>
 inline auto Decoder::decoderFor(SDL_RWops* rwops) -> std::unique_ptr<Decoder>
 {
     static_assert(sizeof...(Decoders) > 0, "Need at least one decoder type.");
-    static_assert((std::is_base_of_v<Aulib::Decoder, Decoders> && ...),
+    static_assert((std::is_base_of<Aulib::Decoder, Decoders>::value && ...),
                   "Decoders must derive from Aulib::Decoder.");
 
     const auto rwPos = SDL_RWtell(rwops);


### PR DESCRIPTION
clang-8 on Slackware 14.2 x86 has fold but not `std::is_base_of_v`.

As seen in https://github.com/diasurgical/devilutionX/issues/516#issuecomment-827706718