### PR TITLE
Eliminate audio delay on second frame of stream playback

### DIFF
--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -72,6 +72,7 @@ auto Aulib::Stream::play(int iterations, std::chrono::microseconds fadeTime) -> 
     d->fCurrentIteration = 0;
     d->fWantedIterations = iterations;
     d->fPlaybackStartTick = SDL_GetTicks();
+    d->fStarting = true;
     if (fadeTime.count() > 0) {
         d->fInternalVolume = 0.f;
         d->fFadingIn = true;

--- a/src/stream_p.cpp
+++ b/src/stream_p.cpp
@@ -132,18 +132,17 @@ void Aulib::Stream_priv::fSdlCallbackImpl(void* /*unused*/, Uint8 out[], int out
 
         bool has_finished = false;
         bool has_looped = false;
-        int cur_pos = 0;
         const int out_offset = [&] {
-            if (ticks_since_play_start < wanted_ticks) {
-                const int out_offset_ticks = wanted_ticks - ticks_since_play_start;
-                const int offset = out_offset_ticks * fAudioSpec.channels * fAudioSpec.freq / 1000;
-                return offset - (offset % fAudioSpec.channels);
+            if (!stream->d->fStarting || ticks_since_play_start >= wanted_ticks) {
+                return 0;
             }
-            return 0;
+
+            const int out_offset_ticks = wanted_ticks - ticks_since_play_start;
+            const int offset = out_offset_ticks * fAudioSpec.channels * fAudioSpec.freq / 1000;
+            return offset - (offset % fAudioSpec.channels);
         }();
-        if (ticks_since_play_start < wanted_ticks) {
-            cur_pos = out_offset;
-        }
+        int cur_pos = out_offset;
+        stream->d->fStarting = false;
 
         while (cur_pos < out_len_samples) {
             if (stream->d->fResampler) {

--- a/src/stream_p.h
+++ b/src/stream_p.h
@@ -40,6 +40,7 @@ struct Stream_priv final
     int fPlaybackStartTick = 0;
     int fFadeInStartTick = 0;
     int fFadeOutStartTick = 0;
+    bool fStarting = false;
     bool fFadingIn = false;
     bool fFadingOut = false;
     bool fStopAfterFade = false;


### PR DESCRIPTION
Based on the issue reported in devilutionX: diasurgical/devilutionX#2888

On my Debian Bullseye system, it seems that a buffer length of 2048 at 22 kHz will result in a buffer duration of ~46 milliseconds. The timer that invokes the audio callback on that system seems to operate at a 25-millisecond resolution, so the interval between callbacks will typically be around either 52 milliseconds or 27 milliseconds. If the delay on the first frame happens to be rather small--for example, 6 milliseconds--and the interval between the first and second frame happens to be 27 milliseconds, the `ticks_since_play_start` on the second frame works out to be less than the 46-millisecond buffer duration--33 milliseconds in our example. In this case, the logic will cause the second frame to be delayed as well, causing a blip in the audio.

In other words, we need a more reliable way to determine whether the delay for a given stream should be applied to the current audio frame. That's the idea behind this PR.

FYI, this also suggests that the delay is only consistent up to to the resolution of the system timer. This could perhaps be improved by capturing the time of the first callback and the total number of callbacks, although that logic could instead be dependent on system performance. Regardless, I deemed it to be out of scope for this fix.