### PR TITLE
Support using SDL_audiolib with `-fno-exceptions`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,6 +407,7 @@ add_library(
     src/ResamplerSpeex.cpp
     src/SdlAudioLocker.h
     src/SdlMutex.h
+    src/SdlMutex.cpp
     src/Stream.cpp
     src/aulib.cpp
     src/aulib_debug.h
@@ -438,6 +439,15 @@ add_library(
     .clang-format
     .github/workflows/ci.yml
 )
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    # Allow using `SDL_audiolib` where exceptions are disabled globally.
+    # This is the only file in the project that requires exceptions.
+    set_source_files_properties(
+        src/SdlMutex.cpp
+        PROPERTIES
+            COMPILE_FLAGS -fexceptions)
+endif()
 
 target_compile_definitions(
     SDL_audiolib

--- a/src/SdlMutex.cpp
+++ b/src/SdlMutex.cpp
@@ -1,0 +1,29 @@
+// This is copyrighted software. More information is at the end of this file.
+#include "SdlMutex.h"
+
+SdlMutex::SdlMutex()
+{
+    if (not mutex_) {
+        throw std::runtime_error(SDL_GetError());
+    }
+}
+/*
+
+Copyright (C) 2021 Nikos Chantziaras.
+
+This file is part of SDL_audiolib.
+
+SDL_audiolib is free software: you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
+
+SDL_audiolib is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with SDL_audiolib. If not, see <http://www.gnu.org/licenses/>.
+
+*/

--- a/src/SdlMutex.h
+++ b/src/SdlMutex.h
@@ -12,12 +12,7 @@
 class SdlMutex final
 {
 public:
-    SdlMutex()
-    {
-        if (not mutex_) {
-            throw std::runtime_error(SDL_GetError());
-        }
-    }
+    SdlMutex();
 
     ~SdlMutex()
     {


### PR DESCRIPTION
When `SDL_audiolib` is included as a subproject and the parent project disables C++ exceptions, it previously failed to compiled due to a single `throw` call in `SdlMutex.h`.

Extracts `SdlMutex.cpp.o` into a separate object library that always has `-fexceptions` to allow building the rest of `SDL_audiolib` without exceptions.