### PR TITLE
Delay `fStreamListMutex` initialization 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,7 @@ add_library(
 
     src/missing.h
     src/missing/algorithm.h
+    src/missing/optional.h
     src/missing/sdl_audio_format.h
     src/missing/sdl_endian_float.h
     src/missing/sdl_load_file_rw.c

--- a/src/SdlMutex.h
+++ b/src/SdlMutex.h
@@ -3,7 +3,6 @@
 #include <SDL_error.h>
 #include <SDL_mutex.h>
 #include <SDL_version.h>
-#include <stdexcept>
 
 /*
  * RAII wrapper for SDL_mutex. Satisfies std's "Lockable" (SDL 2) or "BasicLockable" (SDL 1)
@@ -12,12 +11,10 @@
 class SdlMutex final
 {
 public:
-    SdlMutex()
-    {
-        if (not mutex_) {
-            throw std::runtime_error(SDL_GetError());
-        }
-    }
+    // The mutex must not be null.
+    explicit SdlMutex(SDL_mutex* mutex)
+        : mutex_(mutex)
+    { }
 
     ~SdlMutex()
     {
@@ -45,7 +42,7 @@ public:
     }
 
 private:
-    SDL_mutex* mutex_ = SDL_CreateMutex();
+    SDL_mutex* mutex_;
 };
 
 /*

--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -85,7 +85,7 @@ auto Aulib::Stream::play(int iterations, std::chrono::microseconds fadeTime) -> 
     }
     d->fIsPlaying = true;
     {
-        std::lock_guard<SdlMutex> lock(d->fStreamListMutex);
+        std::lock_guard<SdlMutex> lock(*d->fStreamListMutex);
         d->fStreamList.push_back(this);
     }
     return true;

--- a/src/missing/optional.h
+++ b/src/missing/optional.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifdef __has_include
+#if defined(__cplusplus) && (__cplusplus >= 201606L || _MSC_VER >= 1930) && __has_include(<optional>)
+#include <optional> // IWYU pragma: export
+#elif __has_include(<experimental/optional>)
+#include <experimental/optional> // IWYU pragma: export
+#define optional experimental::optional
+#define nullopt experimental::nullopt
+#else
+#error "Missing support for <optional> or <experimental/optional>"
+#endif
+#else
+#error "__has_include unavailable"
+#endif

--- a/src/stream_p.h
+++ b/src/stream_p.h
@@ -6,6 +6,7 @@
 #include "Buffer.h"
 #include "SdlMutex.h"
 #include "aulib.h"
+#include "missing/optional.h"
 #include <SDL_audio.h>
 #include <chrono>
 #include <memory>
@@ -56,7 +57,7 @@ struct Stream_priv final
     static SDL_AudioDeviceID fDeviceId;
 #endif
     static std::vector<Stream*> fStreamList;
-    static SdlMutex fStreamListMutex;
+    static std::optional<SdlMutex> fStreamListMutex;
 
     // This points to an appropriate converter for the current audio format.
     static void (*fSampleConverter)(Uint8[], const Buffer<float>& src);


### PR DESCRIPTION
Initializes the mutex on `init` and reports errors in the same way as we do for all other errors (via `SDL_GetError()`).

This also eliminates the only use of exceptions in SDL_audiolib.