### PR TITLE
Use std::format and std::print where available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ option(
 
 option(
     WITH_SYSTEM_FMTLIB
-    "Use system-provided fmtlib instead of bundled one."
+    "Use system-provided fmtlib instead of bundled one (only relevant if std::format is not supported)."
     OFF
 )
 
@@ -383,15 +383,33 @@ function(add_bundled_fmtlib)
     add_subdirectory(3rdparty/fmt)
 endfunction()
 
-if (WITH_SYSTEM_FMTLIB)
-    # Only try to find fmt::fmt if it doesn't already exist.
-    # It may exist when SDL_audiolib is used as a subpackage of another CMake project.
-    if(NOT TARGET fmt::fmt)
-        find_package(FMT REQUIRED)
+check_cxx_source_compiles(
+    "
+    #include <format>
+    int main() { return std::format(\"{}\", 42).size(); }
+    "
+    HAVE_STD_FORMAT
+)
+check_cxx_source_compiles(
+    "
+    #include <print>
+    int main() { std::print(\"{}\", 42); return 0; }
+    "
+    HAVE_STD_PRINT
+)
+
+if(NOT HAVE_STD_FORMAT)
+    if (WITH_SYSTEM_FMTLIB)
+        # Only try to find fmt::fmt if it doesn't already exist.
+        # It may exist when SDL_audiolib is used as a subpackage of another CMake project.
+        if(NOT TARGET fmt::fmt)
+            find_package(FMT REQUIRED)
+        endif()
+        set(PKGCONF_REQ_PRIV "${PKGCONF_REQ_PRIV} fmt")
+    else()
+        add_bundled_fmtlib()
     endif()
-    set(PKGCONF_REQ_PRIV "${PKGCONF_REQ_PRIV} fmt")
-else()
-    add_bundled_fmtlib()
+    list(APPEND EXTRA_LIBRARIES fmt::fmt)
 endif()
 
 if(DISABLE_EXCEPTIONS)
@@ -441,6 +459,9 @@ add_library(
 
     src/missing.h
     src/missing/algorithm.h
+    src/missing/format.h
+    src/missing/print.h
+    src/missing/string_view.h
     src/missing/sdl_audio_format.h
     src/missing/sdl_endian_float.h
     src/missing/sdl_load_file_rw.c
@@ -517,7 +538,6 @@ target_link_libraries(
 
     PRIVATE
         ${EXTRA_LIBRARIES}
-        fmt::fmt
 )
 
 if(MSVC)

--- a/src/aulib_log.h
+++ b/src/aulib_log.h
@@ -1,62 +1,76 @@
 // This is copyrighted software. More information is at the end of this file.
 #pragma once
 #include "aulib_config.h"
-#include <fmt/core.h>
+#include "missing/format.h"
+#include "missing/print.h"
+#include "missing/string_view.h"
+#include <cstdio>
+
+namespace Aulib {
+namespace priv {
+
+inline void vlog(FILE* out, string_view prefix, string_view format, format_args&& args)
+{
+    fwrite(prefix.data(), 1, prefix.size(), out);
+    vprint(out, format, args);
+}
+
+inline void vlogLn(FILE* out, string_view prefix, string_view format, format_args&& args)
+{
+    vlog(out, prefix, format, std::forward<format_args>(args));
+    print(out, "\n");
+}
+
+} // namespace priv
+} // namespace Aulib
 
 namespace aulib {
 namespace log {
 
 template <typename... Args>
-void debug([[maybe_unused]] fmt::format_string<Args...>&& fmt_str, [[maybe_unused]] Args&&... args)
+void debug([[maybe_unused]] Aulib::priv::string_view fmt_str, [[maybe_unused]] Args&&... args)
 {
 #if AULIB_DEBUG
-    fmt::print(stderr, "SDL_audiolib debug: {}",
-               fmt::format(std::forward<fmt::format_string<Args...>>(fmt_str),
-                           std::forward<Args>(args)...));
+    Aulib::priv::vlog(
+        stderr, "SDL_audiolib debug: ", fmt_str, Aulib::priv::make_format_args(args...));
 #endif
 }
 
 template <typename... Args>
-void debugLn([[maybe_unused]] fmt::format_string<Args...>&& fmt_str,
-             [[maybe_unused]] Args&&... args)
+void debugLn([[maybe_unused]] Aulib::priv::string_view fmt_str, [[maybe_unused]] Args&&... args)
 {
 #if AULIB_DEBUG
-    fmt::print(stderr, "SDL_audiolib debug: {}\n",
-               fmt::format(std::forward<fmt::format_string<Args...>>(fmt_str),
-                           std::forward<Args>(args)...));
+    Aulib::priv::vlogLn(
+        stderr, "SDL_audiolib debug: ", fmt_str, Aulib::priv::make_format_args(args...));
 #endif
 }
 
 template <typename... Args>
-void warn(fmt::format_string<Args...>&& fmt_str, Args&&... args)
+void warn(Aulib::priv::string_view fmt_str, Args&&... args)
 {
-    fmt::print(stderr, "SDL_audiolib warning: {}",
-               fmt::format(std::forward<fmt::format_string<Args...>>(fmt_str),
-                           std::forward<Args>(args)...));
+    Aulib::priv::vlog(
+        stderr, "SDL_audiolib warning: ", fmt_str, Aulib::priv::make_format_args(args...));
 }
 
 template <typename... Args>
-void warnLn(fmt::format_string<Args...>&& fmt_str, Args&&... args)
+void warnLn(Aulib::priv::string_view fmt_str, Args&&... args)
 {
-    fmt::print(stderr, "SDL_audiolib warning: {}\n",
-               fmt::format(std::forward<fmt::format_string<Args...>>(fmt_str),
-                           std::forward<Args>(args)...));
+    Aulib::priv::vlogLn(
+        stderr, "SDL_audiolib warning: ", fmt_str, Aulib::priv::make_format_args(args...));
 }
 
 template <typename... Args>
-void info(fmt::format_string<Args...>&& fmt_str, Args&&... args)
+void info(Aulib::priv::string_view fmt_str, Args&&... args)
 {
-    fmt::print("SDL_audiolib info: {}",
-               fmt::format(std::forward<fmt::format_string<Args...>>(fmt_str),
-                           std::forward<Args>(args)...));
+    Aulib::priv::vlog(
+        stdout, "SDL_audiolib info: ", fmt_str, Aulib::priv::make_format_args(args...));
 }
 
 template <typename... Args>
-void infoLn(fmt::format_string<Args...>&& fmt_str, Args&&... args)
+void infoLn(Aulib::priv::string_view fmt_str, Args&&... args)
 {
-    fmt::print("SDL_audiolib info: {}\n",
-               fmt::format(std::forward<fmt::format_string<Args...>>(fmt_str),
-                           std::forward<Args>(args)...));
+    Aulib::priv::vlogLn(
+        stdout, "SDL_audiolib info: ", fmt_str, Aulib::priv::make_format_args(args...));
 }
 
 } // namespace log

--- a/src/missing/format.h
+++ b/src/missing/format.h
@@ -1,32 +1,31 @@
 // This is copyrighted software. More information is at the end of this file.
 #pragma once
+#include "aulib_config.h"
 
-#cmakedefine USE_DEC_ADLMIDI 1
-#cmakedefine USE_DEC_BASSMIDI 1
-#cmakedefine USE_DEC_DRFLAC 1
-#cmakedefine USE_DEC_DRMP3 1
-#cmakedefine USE_DEC_DRWAV 1
-#cmakedefine USE_DEC_FLUIDSYNTH 1
-#cmakedefine USE_DEC_LIBOPUSFILE 1
-#cmakedefine USE_DEC_LIBVORBIS 1
-#cmakedefine USE_DEC_MODPLUG 1
-#cmakedefine USE_DEC_MPG123 1
-#cmakedefine USE_DEC_MUSEPACK 1
-#cmakedefine USE_DEC_OPENMPT 1
-#cmakedefine USE_DEC_SNDFILE 1
-#cmakedefine USE_DEC_WILDMIDI 1
-#cmakedefine USE_DEC_XMP 1
-#cmakedefine USE_RESAMP_SOXR 1
-#cmakedefine USE_RESAMP_SRC 1
+#if HAVE_STD_FORMAT
+#include <format>
 
-#cmakedefine HAVE_EXCEPTIONS 1
-#cmakedefine HAVE_STD_CLAMP 1
-#cmakedefine HAVE_STD_FORMAT 1
-#cmakedefine HAVE_STD_PRINT 1
+namespace Aulib {
+namespace priv {
+using std::format;
+using std::format_args;
+using std::make_format_args;
+} // namespace priv
+} // namespace Aulib
+#else
+#include <fmt/core.h>
 
+namespace Aulib {
+namespace priv {
+using fmt::format;
+using fmt::format_args;
+using fmt::make_format_args;
+} // namespace priv
+} // namespace Aulib
+#endif
 /*
 
-Copyright (C) 2014, 2015, 2016, 2017, 2018, 2019 Nikos Chantziaras.
+Copyright (C) 2021 Nikos Chantziaras.
 
 This file is part of SDL_audiolib.
 

--- a/src/missing/print.h
+++ b/src/missing/print.h
@@ -1,32 +1,46 @@
 // This is copyrighted software. More information is at the end of this file.
 #pragma once
+#include "aulib_config.h"
 
-#cmakedefine USE_DEC_ADLMIDI 1
-#cmakedefine USE_DEC_BASSMIDI 1
-#cmakedefine USE_DEC_DRFLAC 1
-#cmakedefine USE_DEC_DRMP3 1
-#cmakedefine USE_DEC_DRWAV 1
-#cmakedefine USE_DEC_FLUIDSYNTH 1
-#cmakedefine USE_DEC_LIBOPUSFILE 1
-#cmakedefine USE_DEC_LIBVORBIS 1
-#cmakedefine USE_DEC_MODPLUG 1
-#cmakedefine USE_DEC_MPG123 1
-#cmakedefine USE_DEC_MUSEPACK 1
-#cmakedefine USE_DEC_OPENMPT 1
-#cmakedefine USE_DEC_SNDFILE 1
-#cmakedefine USE_DEC_WILDMIDI 1
-#cmakedefine USE_DEC_XMP 1
-#cmakedefine USE_RESAMP_SOXR 1
-#cmakedefine USE_RESAMP_SRC 1
+#if HAVE_STD_PRINT
+#include <print>
 
-#cmakedefine HAVE_EXCEPTIONS 1
-#cmakedefine HAVE_STD_CLAMP 1
-#cmakedefine HAVE_STD_FORMAT 1
-#cmakedefine HAVE_STD_PRINT 1
+namespace Aulib {
+namespace priv {
+using std::print;
+using std::vprint;
+} // namespace priv
+} // namespace Aulib
+#elif not HAVE_STD_FORMAT
+#include <fmt/core.h>
 
+namespace Aulib {
+namespace priv {
+using fmt::print;
+using fmt::vprint;
+} // namespace priv
+} // namespace Aulib
+#else
+#include "missing/format.h"
+#include <cstdio>
+
+namespace Aulib {
+namespace priv {
+
+template <typename FormatString, typename... Args>
+void print(FILE* stream, FormatString<Args...>&& fmt_str, Args&&... args)
+{
+    fprintf(
+        stream,
+        std::format(std::forward<FormatString>(fmt_str), std::forward<Args>(args)...).c_str());
+}
+
+} // namespace priv
+} // namespace Aulib
+#endif
 /*
 
-Copyright (C) 2014, 2015, 2016, 2017, 2018, 2019 Nikos Chantziaras.
+Copyright (C) 2021 Nikos Chantziaras.
 
 This file is part of SDL_audiolib.
 

--- a/src/missing/string_view.h
+++ b/src/missing/string_view.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#ifdef __has_include
+#if defined(__cplusplus) && (__cplusplus >= 201703L || _MSC_VER >= 1930) \
+    && __has_include(<string_view>) // should be 201606L, but STL headers disagree
+
+#include <string>
+#include <string_view> // IWYU pragma: export
+namespace Aulib {
+namespace priv {
+using string_view = std::string_view;
+} // namespace priv
+} // namespace Aulib
+#elif __has_include(<experimental/string_view>)
+
+#include <experimental/string_view> // IWYU pragma: export
+namespace Aulib {
+namespace priv {
+using string_view = std::experimental::string_view;
+} // namespace priv
+} // namespace Aulib
+#else
+
+#error "Missing support for <string_view> or <experimental/string_view>"
+#endif
+#else
+
+#error "__has_include unavailable"
+#endif


### PR DESCRIPTION
`std::print` is still a proposal but this simple use of it is unlikely to change by implementation stage.