### PR TITLE
Template everything for int32_t

### DIFF
--- a/include/Aulib/DecoderAdlmidi.h
+++ b/include/Aulib/DecoderAdlmidi.h
@@ -13,7 +13,8 @@ namespace Aulib {
  * This decoder always generates samples at 49716Hz, the native rate of the OPL synths provided by
  * libADLMIDI.
  */
-class AULIB_EXPORT DecoderAdlmidi: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderAdlmidi: public Decoder<T>
 {
 public:
     enum class Emulator
@@ -106,7 +107,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     std::unique_ptr<struct DecoderAdlmidi_priv> d;

--- a/include/Aulib/DecoderBassmidi.h
+++ b/include/Aulib/DecoderBassmidi.h
@@ -8,7 +8,8 @@ namespace Aulib {
 /*!
  * \brief BASSMIDI decoder.
  */
-class AULIB_EXPORT DecoderBassmidi: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderBassmidi: public Decoder<T>
 {
 public:
     DecoderBassmidi();
@@ -35,7 +36,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     const std::unique_ptr<struct DecoderBassmidi_priv> d;

--- a/include/Aulib/DecoderDrflac.h
+++ b/include/Aulib/DecoderDrflac.h
@@ -8,7 +8,8 @@ namespace Aulib {
 /*!
  * \brief dr_flac decoder.
  */
-class AULIB_EXPORT DecoderDrflac: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderDrflac: public Decoder<T>
 {
 public:
     DecoderDrflac();
@@ -22,7 +23,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     std::unique_ptr<struct DecoderDrflac_priv> d;

--- a/include/Aulib/DecoderDrmp3.h
+++ b/include/Aulib/DecoderDrmp3.h
@@ -8,7 +8,8 @@ namespace Aulib {
 /*!
  * \brief dr_mp3 decoder.
  */
-class AULIB_EXPORT DecoderDrmp3: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderDrmp3: public Decoder<T>
 {
 public:
     DecoderDrmp3();
@@ -22,7 +23,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     std::unique_ptr<struct DecoderDrmp3_priv> d;

--- a/include/Aulib/DecoderDrwav.h
+++ b/include/Aulib/DecoderDrwav.h
@@ -9,7 +9,8 @@ namespace Aulib {
 /*!
  * \brief dr_wav decoder.
  */
-class AULIB_EXPORT DecoderDrwav: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderDrwav: public Decoder<T>
 {
 public:
     DecoderDrwav();
@@ -23,7 +24,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     std::unique_ptr<struct DecoderDrwav_priv> d;

--- a/include/Aulib/DecoderFlac.h
+++ b/include/Aulib/DecoderFlac.h
@@ -4,6 +4,17 @@
 
 namespace Aulib {
 
+//! \brief Format of the input file.
+enum class DecoderFlacFileFormat
+{
+    //! Try and detect the format. Only works if the input is seekable.
+    Detect,
+    //! Assume input is raw FLAC.
+    Flac,
+    //! Assume input is FLAC data inside an Ogg container.
+    Ogg,
+};
+
 /*!
  * \brief libFLAC decoder.
  *
@@ -13,21 +24,11 @@ namespace Aulib {
  *
  * \note For Ogg support to work, libFLAC must have been built with Ogg support.
  */
-class AULIB_EXPORT DecoderFlac: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderFlac: public Decoder<T>
 {
 public:
-    //! \brief Format of the input file.
-    enum class FileFormat
-    {
-        //! Try and detect the format. Only works if the input is seekable.
-        Detect,
-        //! Assume input is raw FLAC.
-        Flac,
-        //! Assume input is FLAC data inside an Ogg container.
-        Ogg,
-    };
-
-    DecoderFlac(FileFormat file_type = FileFormat::Detect);
+    DecoderFlac(DecoderFlacFileFormat file_type = DecoderFlacFileFormat::Detect);
     ~DecoderFlac() override;
 
     auto open(SDL_RWops* rwops) -> bool override;
@@ -38,7 +39,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     const std::unique_ptr<struct DecoderFlac_priv> d;

--- a/include/Aulib/DecoderFluidsynth.h
+++ b/include/Aulib/DecoderFluidsynth.h
@@ -8,7 +8,8 @@ namespace Aulib {
 /*!
  * \brief FluidSynth decoder.
  */
-class AULIB_EXPORT DecoderFluidsynth: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderFluidsynth: public Decoder<T>
 {
 public:
     DecoderFluidsynth();
@@ -52,7 +53,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     const std::unique_ptr<struct DecoderFluidsynth_priv> d;

--- a/include/Aulib/DecoderModplug.h
+++ b/include/Aulib/DecoderModplug.h
@@ -8,7 +8,8 @@ namespace Aulib {
 /*!
  * \brief ModPlug decoder.
  */
-class AULIB_EXPORT DecoderModplug: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderModplug: public Decoder<T>
 {
 public:
     DecoderModplug();
@@ -22,7 +23,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     const std::unique_ptr<struct DecoderModplug_priv> d;

--- a/include/Aulib/DecoderMpg123.h
+++ b/include/Aulib/DecoderMpg123.h
@@ -8,7 +8,8 @@ namespace Aulib {
 /*!
  * \brief mpg123 decoder.
  */
-class AULIB_EXPORT DecoderMpg123: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderMpg123: public Decoder<T>
 {
 public:
     DecoderMpg123();
@@ -22,7 +23,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     const std::unique_ptr<struct DecoderMpg123_priv> d;

--- a/include/Aulib/DecoderMusepack.h
+++ b/include/Aulib/DecoderMusepack.h
@@ -8,7 +8,8 @@ namespace Aulib {
 /*!
  * \brief libmpcdec decoder.
  */
-class AULIB_EXPORT DecoderMusepack: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderMusepack: public Decoder<T>
 {
 public:
     DecoderMusepack();
@@ -22,7 +23,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     const std::unique_ptr<struct DecoderMusepack_priv> d;

--- a/include/Aulib/DecoderOpenmpt.h
+++ b/include/Aulib/DecoderOpenmpt.h
@@ -8,7 +8,8 @@ namespace Aulib {
 /*!
  * \brief OpenMPT decoder.
  */
-class AULIB_EXPORT DecoderOpenmpt: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderOpenmpt: public Decoder<T>
 {
 public:
     DecoderOpenmpt();
@@ -22,7 +23,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     const std::unique_ptr<struct DecoderOpenmpt_priv> d;

--- a/include/Aulib/DecoderOpus.h
+++ b/include/Aulib/DecoderOpus.h
@@ -8,7 +8,8 @@ namespace Aulib {
 /*!
  * \brief libopusfile decoder.
  */
-class AULIB_EXPORT DecoderOpus: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderOpus: public Decoder<T>
 {
 public:
     DecoderOpus();
@@ -22,7 +23,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     const std::unique_ptr<struct DecoderOpus_priv> d;

--- a/include/Aulib/DecoderSndfile.h
+++ b/include/Aulib/DecoderSndfile.h
@@ -8,7 +8,8 @@ namespace Aulib {
 /*!
  * \brief Libsndfile decoder.
  */
-class AULIB_EXPORT DecoderSndfile: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderSndfile: public Decoder<T>
 {
 public:
     DecoderSndfile();
@@ -22,7 +23,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     const std::unique_ptr<struct DecoderSndfile_priv> d;

--- a/include/Aulib/DecoderVorbis.h
+++ b/include/Aulib/DecoderVorbis.h
@@ -8,7 +8,8 @@ namespace Aulib {
 /*!
  * \brief libvorbisfile decoder.
  */
-class AULIB_EXPORT DecoderVorbis: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderVorbis: public Decoder<T>
 {
 public:
     DecoderVorbis();
@@ -22,7 +23,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     const std::unique_ptr<struct DecoderVorbis_priv> d;

--- a/include/Aulib/DecoderWildmidi.h
+++ b/include/Aulib/DecoderWildmidi.h
@@ -12,7 +12,8 @@ namespace Aulib {
  * \note Before creating any instances of this class, you need to initialize the WildMIDI library
  * by calling the DecoderWildmidi::init() function once.
  */
-class AULIB_EXPORT DecoderWildmidi: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderWildmidi: public Decoder<T>
 {
 public:
     DecoderWildmidi();
@@ -64,7 +65,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     const std::unique_ptr<struct DecoderWildmidi_priv> d;

--- a/include/Aulib/DecoderXmp.h
+++ b/include/Aulib/DecoderXmp.h
@@ -8,7 +8,8 @@ namespace Aulib {
 /*!
  * \brief XMP decoder.
  */
-class AULIB_EXPORT DecoderXmp: public Decoder
+template <typename T>
+class AULIB_EXPORT DecoderXmp: public Decoder<T>
 {
 public:
     DecoderXmp();
@@ -22,7 +23,7 @@ public:
     auto seekToTime(std::chrono::microseconds pos) -> bool override;
 
 protected:
-    auto doDecoding(float buf[], int len, bool& callAgain) -> int override;
+    auto doDecoding(T buf[], int len, bool& callAgain) -> int override;
 
 private:
     const std::unique_ptr<struct DecoderXmp_priv> d;

--- a/include/Aulib/Processor.h
+++ b/include/Aulib/Processor.h
@@ -10,14 +10,15 @@ namespace Aulib {
  * A processor receives input samples, processes them and produces output samples. It can be used to
  * alter the audio produced by a decoder. Processors run after resampling (if applicable.)
  */
+template <typename T>
 class AULIB_EXPORT Processor
 {
 public:
     Processor();
     virtual ~Processor();
 
-    Processor(const Processor&) = delete;
-    auto operator=(const Processor&) -> Processor& = delete;
+    Processor(const Processor<T>&) = delete;
+    auto operator=(const Processor<T>&) -> Processor<T>& = delete;
 
     /*!
      * \brief Process input samples and write output samples.
@@ -28,7 +29,7 @@ public:
      * \param[in] source Input buffer.
      * \param[in] len Input and output buffer size in samples.
      */
-    virtual void process(float dest[], const float source[], int len) = 0;
+    virtual void process(T dest[], const T source[], int len) = 0;
 };
 
 } // namespace Aulib

--- a/include/Aulib/Resampler.h
+++ b/include/Aulib/Resampler.h
@@ -7,7 +7,9 @@
 
 namespace Aulib {
 
+template <typename T>
 class Decoder;
+template <typename T>
 struct Resampler_priv;
 
 /*!
@@ -15,6 +17,7 @@ struct Resampler_priv;
  *
  * This class receives audio from an Decoder and resamples it to the requested sample rate.
  */
+template <typename T>
 class AULIB_EXPORT Resampler
 {
 public:
@@ -33,7 +36,7 @@ public:
      * \param decoder
      *  The decoder to use as source. Must not be null.
      */
-    void setDecoder(std::shared_ptr<Decoder> decoder);
+    void setDecoder(std::shared_ptr<Decoder<T>> decoder);
 
     /*! \brief Sets the target sample rate, channels and chuck size.
      *
@@ -61,7 +64,7 @@ public:
      * \return The amount of samples that were stored in the buffer. This can be smaller than
      *         'dstLen' if the decoder has no more samples left.
      */
-    auto resample(float dst[], int dstLen) -> int;
+    auto resample(T dst[], int dstLen) -> int;
 
     /*! \brief Discards any samples that have not yet been retrieved with resample().
      *
@@ -116,7 +119,7 @@ protected:
      * there's anything left at the end that cannot be resampled, simply ignore
      * it.
      */
-    virtual void doResampling(float dst[], const float src[], int& dstLen, int& srcLen) = 0;
+    virtual void doResampling(T dst[], const T src[], int& dstLen, int& srcLen) = 0;
 
     /*! \brief Discard any internally held samples.
      *
@@ -131,8 +134,8 @@ protected:
     virtual void doDiscardPendingSamples() = 0;
 
 private:
-    friend Resampler_priv;
-    const std::unique_ptr<Resampler_priv> d;
+    friend struct Resampler_priv<T>;
+    const std::unique_ptr<Resampler_priv<T>> d;
 };
 
 } // namespace Aulib

--- a/include/Aulib/ResamplerSdl.h
+++ b/include/Aulib/ResamplerSdl.h
@@ -19,14 +19,15 @@ struct ResamplerSdl_priv;
  * resampler and you know that the SDL version you're running on was not built with libsamplerate
  * support. If you do want libsamplerate, then you can just use \ref Aulib::ResamplerSrc instead.
  */
-class AULIB_EXPORT ResamplerSdl: public Resampler
+template <typename T>
+class AULIB_EXPORT ResamplerSdl: public Resampler<T>
 {
 public:
     ResamplerSdl();
     ~ResamplerSdl() override;
 
 protected:
-    void doResampling(float dst[], const float src[], int& dstLen, int& srcLen) override;
+    void doResampling(T dst[], const T src[], int& dstLen, int& srcLen) override;
     auto adjustForOutputSpec(int dstRate, int srcRate, int channels) -> int override;
     void doDiscardPendingSamples() override;
 

--- a/include/Aulib/ResamplerSox.h
+++ b/include/Aulib/ResamplerSox.h
@@ -5,12 +5,14 @@
 
 namespace Aulib {
 
+template <typename T>
 struct ResamplerSox_priv;
 
 /*!
  * \brief Sox resampler.
  */
-class AULIB_EXPORT ResamplerSox: public Resampler
+template <typename T>
+class AULIB_EXPORT ResamplerSox: public Resampler<T>
 {
 public:
     /*!
@@ -40,12 +42,12 @@ public:
     auto quality() const noexcept -> Quality;
 
 protected:
-    void doResampling(float dst[], const float src[], int& dstLen, int& srcLen) override;
+    void doResampling(T dst[], const T src[], int& dstLen, int& srcLen) override;
     auto adjustForOutputSpec(int dstRate, int srcRate, int channels) -> int override;
     void doDiscardPendingSamples() override;
 
 private:
-    const std::unique_ptr<ResamplerSox_priv> d;
+    const std::unique_ptr<ResamplerSox_priv<T>> d;
 };
 
 } // namespace Aulib

--- a/include/Aulib/ResamplerSpeex.h
+++ b/include/Aulib/ResamplerSpeex.h
@@ -10,7 +10,8 @@ struct ResamplerSpeex_priv;
 /*!
  * \brief Speex resampler.
  */
-class AULIB_EXPORT ResamplerSpeex: public Resampler
+template <typename T>
+class AULIB_EXPORT ResamplerSpeex: public Resampler<T>
 {
 public:
     /*!
@@ -26,7 +27,7 @@ public:
     void setQuality(int quality);
 
 protected:
-    void doResampling(float dst[], const float src[], int& dstLen, int& srcLen) override;
+    void doResampling(T dst[], const T src[], int& dstLen, int& srcLen) override;
     auto adjustForOutputSpec(int dstRate, int srcRate, int channels) -> int override;
     void doDiscardPendingSamples() override;
 

--- a/include/Aulib/ResamplerSrc.h
+++ b/include/Aulib/ResamplerSrc.h
@@ -5,11 +5,17 @@
 
 namespace Aulib {
 
+template <typename T>
+struct ResamplerSrc_priv;
+
 /*!
  * \brief SRC (libsamplerate) resampler.
  */
-class AULIB_EXPORT ResamplerSrc: public Resampler
+template <typename T>
+class AULIB_EXPORT ResamplerSrc: public Resampler<T>
 {
+    static_assert(std::is_same<T, float>::value, "ResamplerSrc only supports float data");
+
 public:
     /*!
      * \brief SRC resampler quality.
@@ -66,12 +72,12 @@ public:
     auto quality() const noexcept -> Quality;
 
 protected:
-    void doResampling(float dst[], const float src[], int& dstLen, int& srcLen) override;
+    void doResampling(T dst[], const T src[], int& dstLen, int& srcLen) override;
     auto adjustForOutputSpec(int dstRate, int srcRate, int channels) -> int override;
     void doDiscardPendingSamples() override;
 
 private:
-    const std::unique_ptr<struct ResamplerSrc_priv> d;
+    const std::unique_ptr<ResamplerSrc_priv<T>> d;
 };
 
 } // namespace Aulib

--- a/include/Aulib/Stream.h
+++ b/include/Aulib/Stream.h
@@ -15,9 +15,14 @@ struct SDL_AudioSpec;
 
 namespace Aulib {
 
+template <typename T>
 class Decoder;
+template <typename T>
 class Resampler;
+template <typename T>
 class Processor;
+template <typename T>
+struct Stream_priv;
 
 /*!
  * \brief A \ref Stream handles playback for audio produced by a Decoder.
@@ -32,10 +37,11 @@ class Processor;
  * destruction, meaning you should not create a Stream in one thread and destroy it in another
  * without synchronization.
  */
+template <typename T>
 class AULIB_EXPORT Stream
 {
 public:
-    using Callback = std::function<void(Stream&)>;
+    using Callback = std::function<void(Stream<T>&)>;
 
     /*!
      * \brief Constructs an audio stream from the given file name, decoder and resampler.
@@ -50,11 +56,12 @@ public:
      *  Resampler to use for converting the sample rate of the audio we get from the decoder. If
      *  this is null, then no resampling will be performed.
      */
-    explicit Stream(const std::string& filename, std::unique_ptr<Decoder> decoder,
-                    std::unique_ptr<Resampler> resampler);
+    explicit Stream(
+        const std::string& filename, std::unique_ptr<Decoder<T>> decoder,
+        std::unique_ptr<Resampler<T>> resampler);
 
     //! \overload
-    explicit Stream(const std::string& filename, std::unique_ptr<Decoder> decoder);
+    explicit Stream(const std::string& filename, std::unique_ptr<Decoder<T>> decoder);
 
     /*!
      * \brief Constructs an audio stream from the given SDL_RWops, decoder and resampler.
@@ -72,11 +79,12 @@ public:
      * \param closeRw
      *  Specifies whether 'rwops' should be automatically closed when the stream is destroyed.
      */
-    explicit Stream(SDL_RWops* rwops, std::unique_ptr<Decoder> decoder,
-                    std::unique_ptr<Resampler> resampler, bool closeRw);
+    explicit Stream(
+        SDL_RWops* rwops, std::unique_ptr<Decoder<T>> decoder,
+        std::unique_ptr<Resampler<T>> resampler, bool closeRw);
 
     //! \overload
-    explicit Stream(SDL_RWops* rwops, std::unique_ptr<Decoder> decoder, bool closeRw);
+    explicit Stream(SDL_RWops* rwops, std::unique_ptr<Decoder<T>> decoder, bool closeRw);
 
     virtual ~Stream();
 
@@ -294,7 +302,7 @@ public:
      *
      * \param processor The processor to add.
      */
-    void addProcessor(std::shared_ptr<Processor> processor);
+    void addProcessor(std::shared_ptr<Processor<T>> processor);
 
     /*!
      * \brief Remove a processor from the stream.
@@ -303,7 +311,7 @@ public:
      *
      * \param processor Processor to remove.
      */
-    void removeProcessor(Processor* processor);
+    void removeProcessor(Processor<T>* processor);
 
     /*!
      * \brief Remove all processors from the stream.
@@ -326,10 +334,10 @@ protected:
     void invokeLoopCallback();
 
 private:
-    friend struct Stream_priv;
+    friend struct Stream_priv<T>;
     friend auto Aulib::init(int, AudioFormat, int, int, const std::string&) -> bool;
 
-    const std::unique_ptr<struct Stream_priv> d;
+    const std::unique_ptr<Stream_priv<T>> d;
 };
 
 } // namespace Aulib

--- a/include/aulib.h
+++ b/include/aulib.h
@@ -21,6 +21,17 @@ using AudioFormat = Uint16;
 #endif
 
 /*!
+ * \brief Data type for the internall audio buffers.
+ *
+ * FLOAT provides better accuracy while INT32 is useful on devices without an FPU.
+ */
+enum class BufferDataType
+{
+    FLOAT,
+    INT32
+};
+
+/*!
  * \brief Initializes the audio system.
  *
  * \param freq
@@ -52,12 +63,21 @@ using AudioFormat = Uint16;
  *  A UTF-8 string reported by SDL_GetAudioDeviceName() or a driver-specific name as appropriate.
  *  An empty string requests the most reasonable default device.
  *
+ * \param dataType
+ *  Data type of the internal buffers.
+ *  FLOAT provides better accuracy while INT32 is useful on devices without an FPU.
+ *
  * \return
  *  \retval true The audio system was initialized successfully.
  *  \retval false The audio system could not be initialized.
  */
-AULIB_EXPORT auto init(int freq, AudioFormat format, int channels, int frameSize,
-                       const std::string& device = {}) -> bool;
+AULIB_EXPORT auto init(
+    int freq, AudioFormat format, int channels, int frameSize, const std::string& device = {},
+    BufferDataType dataType = BufferDataType::FLOAT) -> bool;
+
+AULIB_EXPORT auto init(
+    int freq, AudioFormat format, int channels, int frameSize,
+    BufferDataType dataType = BufferDataType::FLOAT) -> bool;
 
 /*!
  * \brief Initializes the library for decoding and resampling only.

--- a/src/DecoderFluidsynth.cpp
+++ b/src/DecoderFluidsynth.cpp
@@ -142,13 +142,16 @@ Aulib::DecoderFluidsynth_priv::DecoderFluidsynth_priv()
     fluid_synth_add_sfloader(fSynth.get(), sfloader);
 }
 
-Aulib::DecoderFluidsynth::DecoderFluidsynth()
+template <typename T>
+Aulib::DecoderFluidsynth<T>::DecoderFluidsynth()
     : d(std::make_unique<DecoderFluidsynth_priv>())
 {}
 
-Aulib::DecoderFluidsynth::~DecoderFluidsynth() = default;
+template <typename T>
+Aulib::DecoderFluidsynth<T>::~DecoderFluidsynth() = default;
 
-auto Aulib::DecoderFluidsynth::loadSoundfont(SDL_RWops* rwops) -> bool
+template <typename T>
+auto Aulib::DecoderFluidsynth<T>::loadSoundfont(SDL_RWops* rwops) -> bool
 {
     if (not d->fSynth) {
         return false;
@@ -179,7 +182,8 @@ auto Aulib::DecoderFluidsynth::loadSoundfont(SDL_RWops* rwops) -> bool
     return true;
 }
 
-auto Aulib::DecoderFluidsynth::loadSoundfont(const std::string& filename) -> bool
+template <typename T>
+auto Aulib::DecoderFluidsynth<T>::loadSoundfont(const std::string& filename) -> bool
 {
     if (not d->fSynth) {
         return false;
@@ -191,7 +195,8 @@ auto Aulib::DecoderFluidsynth::loadSoundfont(const std::string& filename) -> boo
     return true;
 }
 
-auto Aulib::DecoderFluidsynth::gain() const -> float
+template <typename T>
+auto Aulib::DecoderFluidsynth<T>::gain() const -> float
 {
     if (not d->fSynth) {
         return 0.f;
@@ -199,7 +204,8 @@ auto Aulib::DecoderFluidsynth::gain() const -> float
     return fluid_synth_get_gain(d->fSynth.get());
 }
 
-void Aulib::DecoderFluidsynth::setGain(float gain)
+template <typename T>
+void Aulib::DecoderFluidsynth<T>::setGain(float gain)
 {
     if (not d->fSynth) {
         return;
@@ -207,9 +213,10 @@ void Aulib::DecoderFluidsynth::setGain(float gain)
     fluid_synth_set_gain(d->fSynth.get(), gain);
 }
 
-auto Aulib::DecoderFluidsynth::open(SDL_RWops* rwops) -> bool
+template <typename T>
+auto Aulib::DecoderFluidsynth<T>::open(SDL_RWops* rwops) -> bool
 {
-    if (isOpen()) {
+    if (this->isOpen()) {
         return true;
     }
     if (not d->fSynth) {
@@ -246,11 +253,12 @@ auto Aulib::DecoderFluidsynth::open(SDL_RWops* rwops) -> bool
         return false;
     }
     d->fMidiData.swap(newMidiData);
-    setIsOpen(true);
+    this->setIsOpen(true);
     return true;
 }
 
-auto Aulib::DecoderFluidsynth::getChannels() const -> int
+template <typename T>
+auto Aulib::DecoderFluidsynth<T>::getChannels() const -> int
 {
     if (not settings) {
         return 0;
@@ -262,7 +270,8 @@ auto Aulib::DecoderFluidsynth::getChannels() const -> int
     return channels * 2;
 }
 
-auto Aulib::DecoderFluidsynth::getRate() const -> int
+template <typename T>
+auto Aulib::DecoderFluidsynth<T>::getRate() const -> int
 {
     if (not settings) {
         return 0;
@@ -273,9 +282,10 @@ auto Aulib::DecoderFluidsynth::getRate() const -> int
     return rate;
 }
 
-auto Aulib::DecoderFluidsynth::doDecoding(float buf[], int len, bool& /*callAgain*/) -> int
+template <typename T>
+auto Aulib::DecoderFluidsynth<T>::doDecoding(T buf[], int len, bool& /*callAgain*/) -> int
 {
-    if (d->fEOF or not isOpen()) {
+    if (d->fEOF or not this->isOpen()) {
         return 0;
     }
 
@@ -290,9 +300,10 @@ auto Aulib::DecoderFluidsynth::doDecoding(float buf[], int len, bool& /*callAgai
     return 0;
 }
 
-auto Aulib::DecoderFluidsynth::rewind() -> bool
+template <typename T>
+auto Aulib::DecoderFluidsynth<T>::rewind() -> bool
 {
-    if (not isOpen()) {
+    if (not this->isOpen()) {
         return false;
     }
 
@@ -308,17 +319,22 @@ auto Aulib::DecoderFluidsynth::rewind() -> bool
     return true;
 }
 
-auto Aulib::DecoderFluidsynth::duration() const -> chrono::microseconds
+template <typename T>
+auto Aulib::DecoderFluidsynth<T>::duration() const -> chrono::microseconds
 {
     SDL_SetError("Duration cannot be determined with this decoder.");
     return {};
 }
 
-auto Aulib::DecoderFluidsynth::seekToTime(chrono::microseconds /*pos*/) -> bool
+template <typename T>
+auto Aulib::DecoderFluidsynth<T>::seekToTime(chrono::microseconds /*pos*/) -> bool
 {
     SDL_SetError("Seeking is not supported with this decoder.");
     return false;
 }
+
+template class Aulib::DecoderFluidsynth<float>;
+template class Aulib::DecoderFluidsynth<int32_t>;
 
 /*
 

--- a/src/DecoderModplug.cpp
+++ b/src/DecoderModplug.cpp
@@ -48,15 +48,18 @@ Aulib::DecoderModplug_priv::DecoderModplug_priv()
     }
 }
 
-Aulib::DecoderModplug::DecoderModplug()
+template <typename T>
+Aulib::DecoderModplug<T>::DecoderModplug()
     : d(std::make_unique<DecoderModplug_priv>())
 {}
 
-Aulib::DecoderModplug::~DecoderModplug() = default;
+template <typename T>
+Aulib::DecoderModplug<T>::~DecoderModplug() = default;
 
-auto Aulib::DecoderModplug::open(SDL_RWops* rwops) -> bool
+template <typename T>
+auto Aulib::DecoderModplug<T>::open(SDL_RWops* rwops) -> bool
 {
-    if (isOpen()) {
+    if (this->isOpen()) {
         return true;
     }
     // FIXME: error reporting
@@ -74,23 +77,26 @@ auto Aulib::DecoderModplug::open(SDL_RWops* rwops) -> bool
     }
     ModPlug_SetMasterVolume(d->mpHandle.get(), 192);
     d->fDuration = chrono::milliseconds(ModPlug_GetLength(d->mpHandle.get()));
-    setIsOpen(true);
+    this->setIsOpen(true);
     return true;
 }
 
-auto Aulib::DecoderModplug::getChannels() const -> int
+template <typename T>
+auto Aulib::DecoderModplug<T>::getChannels() const -> int
 {
     return modplugSettings.mChannels;
 }
 
-auto Aulib::DecoderModplug::getRate() const -> int
+template <typename T>
+auto Aulib::DecoderModplug<T>::getRate() const -> int
 {
     return modplugSettings.mFrequency;
 }
 
-auto Aulib::DecoderModplug::doDecoding(float buf[], int len, bool& /*callAgain*/) -> int
+template <typename T>
+auto Aulib::DecoderModplug<T>::doDecoding(T buf[], int len, bool& /*callAgain*/) -> int
 {
-    if (d->atEOF or not isOpen()) {
+    if (d->atEOF or not this->isOpen()) {
         return 0;
     }
     Buffer<Sint32> tmpBuf(len);
@@ -105,25 +111,31 @@ auto Aulib::DecoderModplug::doDecoding(float buf[], int len, bool& /*callAgain*/
     return ret / static_cast<int>(sizeof(*buf));
 }
 
-auto Aulib::DecoderModplug::rewind() -> bool
+template <typename T>
+auto Aulib::DecoderModplug<T>::rewind() -> bool
 {
     return seekToTime(chrono::microseconds::zero());
 }
 
-auto Aulib::DecoderModplug::duration() const -> chrono::microseconds
+template <typename T>
+auto Aulib::DecoderModplug<T>::duration() const -> chrono::microseconds
 {
     return d->fDuration;
 }
 
-auto Aulib::DecoderModplug::seekToTime(chrono::microseconds pos) -> bool
+template <typename T>
+auto Aulib::DecoderModplug<T>::seekToTime(chrono::microseconds pos) -> bool
 {
-    if (not isOpen()) {
+    if (not this->isOpen()) {
         return false;
     }
     ModPlug_Seek(d->mpHandle.get(), chrono::duration_cast<chrono::milliseconds>(pos).count());
     d->atEOF = false;
     return true;
 }
+
+template class Aulib::DecoderModplug<float>;
+template class Aulib::DecoderModplug<int32_t>;
 
 /*
 

--- a/src/DecoderMpg123.cpp
+++ b/src/DecoderMpg123.cpp
@@ -80,15 +80,18 @@ Aulib::DecoderMpg123_priv::DecoderMpg123_priv()
     }
 }
 
-Aulib::DecoderMpg123::DecoderMpg123()
+template <typename T>
+Aulib::DecoderMpg123<T>::DecoderMpg123()
     : d(std::make_unique<DecoderMpg123_priv>())
 {}
 
-Aulib::DecoderMpg123::~DecoderMpg123() = default;
+template <typename T>
+Aulib::DecoderMpg123<T>::~DecoderMpg123() = default;
 
-auto Aulib::DecoderMpg123::open(SDL_RWops* rwops) -> bool
+template <typename T>
+auto Aulib::DecoderMpg123<T>::open(SDL_RWops* rwops) -> bool
 {
-    if (isOpen()) {
+    if (this->isOpen()) {
         return true;
     }
     if (not initialized) {
@@ -120,23 +123,26 @@ auto Aulib::DecoderMpg123::open(SDL_RWops* rwops) -> bool
         d->fDuration =
             duration_cast<microseconds>(duration<double>(static_cast<double>(len) / rate));
     }
-    setIsOpen(true);
+    this->setIsOpen(true);
     return true;
 }
 
-auto Aulib::DecoderMpg123::getChannels() const -> int
+template <typename T>
+auto Aulib::DecoderMpg123<T>::getChannels() const -> int
 {
     return d->fChannels;
 }
 
-auto Aulib::DecoderMpg123::getRate() const -> int
+template <typename T>
+auto Aulib::DecoderMpg123<T>::getRate() const -> int
 {
     return d->fRate;
 }
 
-auto Aulib::DecoderMpg123::doDecoding(float buf[], int len, bool& callAgain) -> int
+template <typename T>
+auto Aulib::DecoderMpg123<T>::doDecoding(T buf[], int len, bool& callAgain) -> int
 {
-    if (d->fEOF or not isOpen()) {
+    if (d->fEOF or not this->isOpen()) {
         return 0;
     }
 
@@ -163,25 +169,28 @@ auto Aulib::DecoderMpg123::doDecoding(float buf[], int len, bool& callAgain) -> 
     return totalBytes / static_cast<int>(sizeof(*buf));
 }
 
-auto Aulib::DecoderMpg123::rewind() -> bool
+template <typename T>
+auto Aulib::DecoderMpg123<T>::rewind() -> bool
 {
-    if (not isOpen() or mpg123_seek(d->fMpgHandle.get(), 0, SEEK_SET) < 0) {
+    if (not this->isOpen() or mpg123_seek(d->fMpgHandle.get(), 0, SEEK_SET) < 0) {
         return false;
     }
     d->fEOF = false;
     return true;
 }
 
-auto Aulib::DecoderMpg123::duration() const -> chrono::microseconds
+template <typename T>
+auto Aulib::DecoderMpg123<T>::duration() const -> chrono::microseconds
 {
     return d->fDuration;
 }
 
-auto Aulib::DecoderMpg123::seekToTime(chrono::microseconds pos) -> bool
+template <typename T>
+auto Aulib::DecoderMpg123<T>::seekToTime(chrono::microseconds pos) -> bool
 {
     using std::chrono::duration;
 
-    if (not isOpen()) {
+    if (not this->isOpen()) {
         return false;
     }
 
@@ -192,6 +201,9 @@ auto Aulib::DecoderMpg123::seekToTime(chrono::microseconds pos) -> bool
     d->fEOF = false;
     return true;
 }
+
+template class Aulib::DecoderMpg123<float>;
+template class Aulib::DecoderMpg123<int32_t>;
 
 /*
 

--- a/src/DecoderOpenmpt.cpp
+++ b/src/DecoderOpenmpt.cpp
@@ -23,15 +23,18 @@ struct DecoderOpenmpt_priv final
 
 } // namespace Aulib
 
-Aulib::DecoderOpenmpt::DecoderOpenmpt()
+template <typename T>
+Aulib::DecoderOpenmpt<T>::DecoderOpenmpt()
     : d(std::make_unique<DecoderOpenmpt_priv>())
 {}
 
-Aulib::DecoderOpenmpt::~DecoderOpenmpt() = default;
+template <typename T>
+Aulib::DecoderOpenmpt<T>::~DecoderOpenmpt() = default;
 
-auto Aulib::DecoderOpenmpt::open(SDL_RWops* rwops) -> bool
+template <typename T>
+auto Aulib::DecoderOpenmpt<T>::open(SDL_RWops* rwops) -> bool
 {
-    if (isOpen()) {
+    if (this->isOpen()) {
         return true;
     }
     // FIXME: error reporting
@@ -56,33 +59,38 @@ auto Aulib::DecoderOpenmpt::open(SDL_RWops* rwops) -> bool
     d->fDuration = chrono::duration_cast<chrono::microseconds>(
         chrono::duration<double>(module->get_duration_seconds()));
     d->fModule.swap(module);
-    setIsOpen(true);
+    this->setIsOpen(true);
     return true;
 }
 
-auto Aulib::DecoderOpenmpt::getChannels() const -> int
+template <typename T>
+auto Aulib::DecoderOpenmpt<T>::getChannels() const -> int
 {
     return Aulib::channelCount();
 }
 
-auto Aulib::DecoderOpenmpt::getRate() const -> int
+template <typename T>
+auto Aulib::DecoderOpenmpt<T>::getRate() const -> int
 {
     return Aulib::sampleRate();
 }
 
-auto Aulib::DecoderOpenmpt::rewind() -> bool
+template <typename T>
+auto Aulib::DecoderOpenmpt<T>::rewind() -> bool
 {
     return seekToTime(chrono::microseconds::zero());
 }
 
-auto Aulib::DecoderOpenmpt::duration() const -> chrono::microseconds
+template <typename T>
+auto Aulib::DecoderOpenmpt<T>::duration() const -> chrono::microseconds
 {
     return d->fDuration;
 }
 
-auto Aulib::DecoderOpenmpt::seekToTime(chrono::microseconds pos) -> bool
+template <typename T>
+auto Aulib::DecoderOpenmpt<T>::seekToTime(chrono::microseconds pos) -> bool
 {
-    if (not isOpen()) {
+    if (not this->isOpen()) {
         return false;
     }
 
@@ -91,9 +99,10 @@ auto Aulib::DecoderOpenmpt::seekToTime(chrono::microseconds pos) -> bool
     return true;
 }
 
-auto Aulib::DecoderOpenmpt::doDecoding(float buf[], int len, bool& /*callAgain*/) -> int
+template <typename T>
+auto Aulib::DecoderOpenmpt<T>::doDecoding(T buf[], int len, bool& /*callAgain*/) -> int
 {
-    if (d->atEOF or not isOpen()) {
+    if (d->atEOF or not this->isOpen()) {
         return 0;
     }
     int ret;
@@ -110,6 +119,10 @@ auto Aulib::DecoderOpenmpt::doDecoding(float buf[], int len, bool& /*callAgain*/
     }
     return ret;
 }
+
+template class Aulib::DecoderOpenmpt<float>;
+
+// template class Aulib::DecoderOpenmpt<int32_t>;
 
 /*
 

--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -1,8 +1,16 @@
 // This is copyrighted software. More information is at the end of this file.
 #include "Aulib/Processor.h"
 
-Aulib::Processor::Processor() = default;
-Aulib::Processor::~Processor() = default;
+#include <cstdint>
+
+template <typename T>
+Aulib::Processor<T>::Processor() = default;
+
+template <typename T>
+Aulib::Processor<T>::~Processor() = default;
+
+template class Aulib::Processor<float>;
+template class Aulib::Processor<int32_t>;
 
 /*
 

--- a/src/ResamplerSdl.cpp
+++ b/src/ResamplerSdl.cpp
@@ -15,13 +15,16 @@ struct ResamplerSdl_priv final
 
 } // namespace Aulib
 
-Aulib::ResamplerSdl::ResamplerSdl()
+template <typename T>
+Aulib::ResamplerSdl<T>::ResamplerSdl()
     : d(std::make_unique<ResamplerSdl_priv>())
 {}
 
-Aulib::ResamplerSdl::~ResamplerSdl() = default;
+template <typename T>
+Aulib::ResamplerSdl<T>::~ResamplerSdl() = default;
 
-void Aulib::ResamplerSdl::doResampling(float dst[], const float src[], int& dstLen, int& srcLen)
+template <typename T>
+void Aulib::ResamplerSdl<T>::doResampling(T dst[], const T src[], int& dstLen, int& srcLen)
 {
     if (not d->fResampler) {
         dstLen = srcLen = 0;
@@ -42,23 +45,29 @@ void Aulib::ResamplerSdl::doResampling(float dst[], const float src[], int& dstL
     dstLen = bytes_resampled / sizeof(*dst);
 }
 
-auto Aulib::ResamplerSdl::adjustForOutputSpec(const int dstRate, const int srcRate,
+template <typename T>
+auto Aulib::ResamplerSdl<T>::adjustForOutputSpec(const int dstRate, const int srcRate,
                                               const int channels) -> int
 {
-    d->fResampler.reset(
-        SDL_NewAudioStream(AUDIO_F32, channels, srcRate, AUDIO_F32, channels, dstRate));
+    d->fResampler.reset(SDL_NewAudioStream(
+        std::is_same<T, float>::value ? AUDIO_F32 : AUDIO_S32, channels, srcRate,
+        std::is_same<T, float>::value ? AUDIO_F32 : AUDIO_S32, channels, dstRate));
     if (not d->fResampler) {
         return -1;
     }
     return 0;
 }
 
-void Aulib::ResamplerSdl::doDiscardPendingSamples()
+template <typename T>
+void Aulib::ResamplerSdl<T>::doDiscardPendingSamples()
 {
     if (d->fResampler) {
         SDL_AudioStreamClear(d->fResampler.get());
     }
 }
+
+template class Aulib::ResamplerSdl<float>;
+template class Aulib::ResamplerSdl<int32_t>;
 
 #endif // SDL_VERSION_ATLEAST
 

--- a/src/SdlAudioLocker.h
+++ b/src/SdlAudioLocker.h
@@ -13,7 +13,7 @@ public:
     SdlAudioLocker()
     {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-        SDL_LockAudioDevice(Aulib::Stream_priv::fDeviceId);
+        SDL_LockAudioDevice(Aulib::Stream_priv_device::fDeviceId);
 #else
         SDL_LockAudio();
 #endif
@@ -32,7 +32,7 @@ public:
     {
         if (fIsLocked) {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-            SDL_UnlockAudioDevice(Aulib::Stream_priv::fDeviceId);
+            SDL_UnlockAudioDevice(Aulib::Stream_priv_device::fDeviceId);
 #else
             SDL_UnlockAudio();
 #endif

--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -15,33 +15,41 @@
 #include <SDL_timer.h>
 #include <mutex>
 
-Aulib::Stream::Stream(const std::string& filename, std::unique_ptr<Decoder> decoder,
-                      std::unique_ptr<Resampler> resampler)
+template <typename T>
+Aulib::Stream<T>::Stream(
+    const std::string& filename, std::unique_ptr<Decoder<T>> decoder,
+    std::unique_ptr<Resampler<T>> resampler)
     : Stream(SDL_RWFromFile(filename.c_str(), "rb"), std::move(decoder), std::move(resampler), true)
 {}
 
-Aulib::Stream::Stream(const std::string& filename, std::unique_ptr<Decoder> decoder)
+template <typename T>
+Aulib::Stream<T>::Stream(const std::string& filename, std::unique_ptr<Decoder<T>> decoder)
     : Stream(SDL_RWFromFile(filename.c_str(), "rb"), std::move(decoder), true)
 {}
 
-Aulib::Stream::Stream(SDL_RWops* rwops, std::unique_ptr<Decoder> decoder,
-                      std::unique_ptr<Resampler> resampler, bool closeRw)
-    : d(std::make_unique<Stream_priv>(this, std::move(decoder), std::move(resampler), rwops,
-                                      closeRw))
+template <typename T>
+Aulib::Stream<T>::Stream(
+    SDL_RWops* rwops, std::unique_ptr<Decoder<T>> decoder, std::unique_ptr<Resampler<T>> resampler,
+    bool closeRw)
+    : d(std::make_unique<Stream_priv<T>>(
+        this, std::move(decoder), std::move(resampler), rwops, closeRw))
 {}
 
-Aulib::Stream::Stream(SDL_RWops* rwops, std::unique_ptr<Decoder> decoder, bool closeRw)
-    : d(std::make_unique<Stream_priv>(this, std::move(decoder), nullptr, rwops, closeRw))
+template <typename T>
+Aulib::Stream<T>::Stream(SDL_RWops* rwops, std::unique_ptr<Decoder<T>> decoder, bool closeRw)
+    : d(std::make_unique<Stream_priv<T>>(this, std::move(decoder), nullptr, rwops, closeRw))
 {}
 
-Aulib::Stream::~Stream()
+template <typename T>
+Aulib::Stream<T>::~Stream()
 {
     SdlAudioLocker lock;
 
     d->fStop();
 }
 
-auto Aulib::Stream::open() -> bool
+template <typename T>
+auto Aulib::Stream<T>::open() -> bool
 {
     SdlAudioLocker lock;
 
@@ -58,7 +66,8 @@ auto Aulib::Stream::open() -> bool
     return true;
 }
 
-auto Aulib::Stream::play(int iterations, std::chrono::microseconds fadeTime) -> bool
+template <typename T>
+auto Aulib::Stream<T>::play(int iterations, std::chrono::microseconds fadeTime) -> bool
 {
     if (not open()) {
         return false;
@@ -91,7 +100,8 @@ auto Aulib::Stream::play(int iterations, std::chrono::microseconds fadeTime) -> 
     return true;
 }
 
-void Aulib::Stream::stop(std::chrono::microseconds fadeTime)
+template <typename T>
+void Aulib::Stream<T>::stop(std::chrono::microseconds fadeTime)
 {
     SdlAudioLocker lock;
 
@@ -106,7 +116,8 @@ void Aulib::Stream::stop(std::chrono::microseconds fadeTime)
     }
 }
 
-void Aulib::Stream::pause(std::chrono::microseconds fadeTime)
+template <typename T>
+void Aulib::Stream<T>::pause(std::chrono::microseconds fadeTime)
 {
     if (not open()) {
         return;
@@ -128,7 +139,8 @@ void Aulib::Stream::pause(std::chrono::microseconds fadeTime)
     }
 }
 
-void Aulib::Stream::resume(std::chrono::microseconds fadeTime)
+template <typename T>
+void Aulib::Stream<T>::resume(std::chrono::microseconds fadeTime)
 {
     SdlAudioLocker locker;
 
@@ -147,7 +159,8 @@ void Aulib::Stream::resume(std::chrono::microseconds fadeTime)
     d->fIsPaused = false;
 }
 
-auto Aulib::Stream::rewind() -> bool
+template <typename T>
+auto Aulib::Stream<T>::rewind() -> bool
 {
     if (not open()) {
         return false;
@@ -157,7 +170,8 @@ auto Aulib::Stream::rewind() -> bool
     return d->fDecoder->rewind();
 }
 
-void Aulib::Stream::setVolume(float volume)
+template <typename T>
+void Aulib::Stream<T>::setVolume(float volume)
 {
     SdlAudioLocker locker;
 
@@ -167,151 +181,176 @@ void Aulib::Stream::setVolume(float volume)
     d->fVolume = volume;
 }
 
-auto Aulib::Stream::volume() const -> float
+template <typename T>
+auto Aulib::Stream<T>::volume() const -> float
 {
     SdlAudioLocker locker;
 
     return d->fVolume;
 }
 
-void Aulib::Stream::setStereoPosition(const float position)
+template <typename T>
+void Aulib::Stream<T>::setStereoPosition(const float position)
 {
     SdlAudioLocker locker;
 
     d->fStereoPos = Aulib::priv::clamp(position, -1.f, 1.f);
 }
 
-auto Aulib::Stream::getStereoPosition() const -> float
+template <typename T>
+auto Aulib::Stream<T>::getStereoPosition() const -> float
 {
     SdlAudioLocker locker;
 
     return d->fStereoPos;
 }
 
-void Aulib::Stream::mute()
+template <typename T>
+void Aulib::Stream<T>::mute()
 {
     SdlAudioLocker locker;
 
     d->fIsMuted = true;
 }
 
-void Aulib::Stream::unmute()
+template <typename T>
+void Aulib::Stream<T>::unmute()
 {
     SdlAudioLocker locker;
 
     d->fIsMuted = false;
 }
 
-auto Aulib::Stream::isMuted() const -> bool
+template <typename T>
+auto Aulib::Stream<T>::isMuted() const -> bool
 {
     SdlAudioLocker locker;
 
     return d->fIsMuted;
 }
 
-auto Aulib::Stream::isPlaying() const -> bool
+template <typename T>
+auto Aulib::Stream<T>::isPlaying() const -> bool
 {
     SdlAudioLocker locker;
 
     return d->fIsPlaying;
 }
 
-auto Aulib::Stream::isPaused() const -> bool
+template <typename T>
+auto Aulib::Stream<T>::isPaused() const -> bool
 {
     SdlAudioLocker locker;
 
     return d->fIsPaused;
 }
 
-auto Aulib::Stream::duration() const -> std::chrono::microseconds
+template <typename T>
+auto Aulib::Stream<T>::duration() const -> std::chrono::microseconds
 {
     SdlAudioLocker locker;
 
     return d->fDecoder->duration();
 }
 
-auto Aulib::Stream::seekToTime(std::chrono::microseconds pos) -> bool
+template <typename T>
+auto Aulib::Stream<T>::seekToTime(std::chrono::microseconds pos) -> bool
 {
     SdlAudioLocker locker;
 
     return d->fDecoder->seekToTime(pos);
 }
 
-void Aulib::Stream::setFinishCallback(Callback func)
+template <typename T>
+void Aulib::Stream<T>::setFinishCallback(Callback func)
 {
     SdlAudioLocker locker;
 
     d->fFinishCallback = std::move(func);
 }
 
-void Aulib::Stream::unsetFinishCallback()
+template <typename T>
+void Aulib::Stream<T>::unsetFinishCallback()
 {
     SdlAudioLocker locker;
 
     d->fFinishCallback = nullptr;
 }
 
-void Aulib::Stream::setLoopCallback(Callback func)
+template <typename T>
+void Aulib::Stream<T>::setLoopCallback(Callback func)
 {
     SdlAudioLocker locker;
 
     d->fLoopCallback = std::move(func);
 }
 
-void Aulib::Stream::unsetLoopCallback()
+template <typename T>
+void Aulib::Stream<T>::unsetLoopCallback()
 {
     SdlAudioLocker locker;
 
     d->fLoopCallback = nullptr;
 }
 
-void Aulib::Stream::addProcessor(std::shared_ptr<Processor> processor)
+template <typename T>
+void Aulib::Stream<T>::addProcessor(std::shared_ptr<Processor<T>> processor)
 {
     SdlAudioLocker locker;
 
     if (not processor
         or std::find_if(
                d->processors.begin(), d->processors.end(),
-               [&processor](std::shared_ptr<Processor>& p) { return p.get() == processor.get(); })
-               != d->processors.end()) {
+               [&processor](std::shared_ptr<Processor<T>>& p) {
+                   return p.get() == processor.get();
+               })
+               != d->processors.end())
+    {
         return;
     }
     d->processors.push_back(std::move(processor));
 }
 
-void Aulib::Stream::removeProcessor(Processor* processor)
+template <typename T>
+void Aulib::Stream<T>::removeProcessor(Processor<T>* processor)
 {
     SdlAudioLocker locker;
 
-    auto it =
-        std::find_if(d->processors.begin(), d->processors.end(),
-                     [&processor](std::shared_ptr<Processor>& p) { return p.get() == processor; });
+    auto it = std::find_if(
+        d->processors.begin(), d->processors.end(),
+        [&processor](std::shared_ptr<Processor<T>>& p) { return p.get() == processor; });
     if (it == d->processors.end()) {
         return;
     }
     d->processors.erase(it);
 }
 
-void Aulib::Stream::clearProcessors()
+template <typename T>
+void Aulib::Stream<T>::clearProcessors()
 {
     SdlAudioLocker locker;
 
     d->processors.clear();
 }
 
-void Aulib::Stream::invokeFinishCallback()
+template <typename T>
+void Aulib::Stream<T>::invokeFinishCallback()
 {
     if (d->fFinishCallback) {
         d->fFinishCallback(*this);
     }
 }
 
-void Aulib::Stream::invokeLoopCallback()
+template <typename T>
+void Aulib::Stream<T>::invokeLoopCallback()
 {
     if (d->fLoopCallback) {
         d->fLoopCallback(*this);
     }
 }
+
+template class Aulib::Stream<float>;
+template class Aulib::Stream<int32_t>;
 
 /*
 

--- a/src/aulib.cpp
+++ b/src/aulib.cpp
@@ -22,12 +22,112 @@ static InitType gInitType = InitType::None;
 extern "C" {
 static void sdlCallback(void* /*unused*/, Uint8 out[], int outLen)
 {
-    Aulib::Stream_priv::fSdlCallbackImpl(nullptr, out, outLen);
+    switch (Aulib::Stream_priv_device::fDataType) {
+    case Aulib::BufferDataType::FLOAT:
+        Aulib::Stream_priv<float>::fSdlCallbackImpl(nullptr, out, outLen);
+        break;
+    case Aulib::BufferDataType::INT32:
+        Aulib::Stream_priv<int32_t>::fSdlCallbackImpl(nullptr, out, outLen);
+        break;
+    }
 }
 }
 
-auto Aulib::init(int freq, AudioFormat format, int channels, int frameSize,
-                 const std::string& device) -> bool
+namespace {
+
+auto getFloatSampleConverter(uint16_t format) -> void (*)(Uint8[], const Buffer<float>& src)
+{
+    switch (format) {
+    case AUDIO_S8:
+        aulib::log::debugLn("S8");
+        return Aulib::floatToS8;
+        break;
+    case AUDIO_U8:
+        aulib::log::debugLn("U8");
+        return Aulib::floatToU8;
+    case AUDIO_S16LSB:
+        aulib::log::debugLn("S16LSB");
+        return Aulib::floatToS16LSB;
+    case AUDIO_U16LSB:
+        aulib::log::debugLn("U16LSB");
+        return Aulib::floatToU16LSB;
+    case AUDIO_S16MSB:
+        aulib::log::debugLn("S16MSB");
+        return Aulib::floatToS16MSB;
+    case AUDIO_U16MSB:
+        aulib::log::debugLn("U16MSB");
+        return Aulib::floatToU16MSB;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    case AUDIO_S32LSB:
+        aulib::log::debugLn("S32LSB");
+        return Aulib::floatToS32LSB;
+    case AUDIO_S32MSB:
+        aulib::log::debugLn("S32MSB");
+        return Aulib::floatToS32MSB;
+    case AUDIO_F32LSB:
+        aulib::log::debugLn("F32LSB");
+        return Aulib::floatToFloatLSB;
+    case AUDIO_F32MSB:
+        aulib::log::debugLn("F32MSB");
+        return Aulib::floatToFloatMSB;
+#endif
+    default:
+        return nullptr;
+    }
+}
+
+auto getInt32SampleConverter(uint16_t format) -> void (*)(Uint8[], const Buffer<int32_t>& src)
+{
+    switch (format) {
+    case AUDIO_S8:
+        aulib::log::debugLn("S8");
+        return Aulib::int32ToS8;
+        break;
+    case AUDIO_U8:
+        aulib::log::debugLn("U8");
+        return Aulib::int32ToU8;
+    case AUDIO_S16LSB:
+        aulib::log::debugLn("S16LSB");
+        return Aulib::int32ToS16LSB;
+    case AUDIO_U16LSB:
+        aulib::log::debugLn("U16LSB");
+        return Aulib::int32ToU16LSB;
+    case AUDIO_S16MSB:
+        aulib::log::debugLn("S16MSB");
+        return Aulib::int32ToS16MSB;
+    case AUDIO_U16MSB:
+        aulib::log::debugLn("U16MSB");
+        return Aulib::int32ToU16MSB;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    case AUDIO_S32LSB:
+        aulib::log::debugLn("S32LSB");
+        return Aulib::int32ToS32LSB;
+    case AUDIO_S32MSB:
+        aulib::log::debugLn("S32MSB");
+        return Aulib::int32ToS32MSB;
+    case AUDIO_F32LSB:
+        aulib::log::debugLn("F32LSB");
+        return Aulib::int32ToFloatLSB;
+    case AUDIO_F32MSB:
+        aulib::log::debugLn("F32MSB");
+        return Aulib::int32ToFloatMSB;
+#endif
+    default:
+        return nullptr;
+    }
+}
+
+} // namespace
+
+auto Aulib::init(int freq, AudioFormat format, int channels, int frameSize, BufferDataType dataType)
+    -> bool
+{
+    return init(freq, format, channels, frameSize, {}, dataType);
+}
+
+auto Aulib::init(
+    int freq, AudioFormat format, int channels, int frameSize, const std::string& device,
+    BufferDataType dataType) -> bool
 {
     if (gInitType != InitType::None) {
         SDL_SetError("SDL_audiolib already initialized, cannot initialize again.");
@@ -47,77 +147,49 @@ auto Aulib::init(int freq, AudioFormat format, int channels, int frameSize,
     requestedSpec.channels = channels;
     requestedSpec.samples = frameSize;
     requestedSpec.callback = ::sdlCallback;
-    Stream_priv::fAudioSpec = requestedSpec;
+    Stream_priv_device::fAudioSpec = requestedSpec;
+    Stream_priv_device::fDataType = dataType;
 #if SDL_VERSION_ATLEAST(2, 0, 0)
     auto flags = SDL_AUDIO_ALLOW_FREQUENCY_CHANGE | SDL_AUDIO_ALLOW_FORMAT_CHANGE;
 #    if SDL_VERSION_ATLEAST(2, 0, 9)
     flags |= SDL_AUDIO_ALLOW_SAMPLES_CHANGE;
 #    endif
-    Stream_priv::fDeviceId = SDL_OpenAudioDevice(device.empty() ? nullptr : device.c_str(), false,
-                                                 &requestedSpec, &Stream_priv::fAudioSpec, flags);
-    if (Stream_priv::fDeviceId == 0) {
+    Stream_priv_device::fDeviceId = SDL_OpenAudioDevice(
+        device.empty() ? nullptr : device.c_str(), false, &requestedSpec,
+        &Stream_priv_device::fAudioSpec, flags);
+    if (Stream_priv_device::fDeviceId == 0) {
         Aulib::quit();
         return false;
     }
 #else
-    if (SDL_OpenAudio(&requestedSpec, &Stream_priv::fAudioSpec) == -1) {
+    if (SDL_OpenAudio(&requestedSpec, &Stream_priv_device::fAudioSpec) == -1) {
         Aulib::quit();
         return false;
     }
 #endif
 
     aulib::log::debug("SDL initialized with sample format: ");
-    switch (Stream_priv::fAudioSpec.format) {
-    case AUDIO_S8:
-        aulib::log::debugLn("S8");
-        Stream_priv::fSampleConverter = Aulib::floatToS8;
+    bool sampleConverterFound = false;
+    switch (dataType) {
+    case BufferDataType::FLOAT:
+        Stream_priv<float>::fSampleConverter =
+            getFloatSampleConverter(Stream_priv_device::fAudioSpec.format);
+        sampleConverterFound = Stream_priv<float>::fSampleConverter != nullptr;
         break;
-    case AUDIO_U8:
-        aulib::log::debugLn("U8");
-        Stream_priv::fSampleConverter = Aulib::floatToU8;
+    case BufferDataType::INT32:
+        Stream_priv<int32_t>::fSampleConverter =
+            getInt32SampleConverter(Stream_priv_device::fAudioSpec.format);
+        sampleConverterFound = Stream_priv<int32_t>::fSampleConverter != nullptr;
         break;
-    case AUDIO_S16LSB:
-        aulib::log::debugLn("S16LSB");
-        Stream_priv::fSampleConverter = Aulib::floatToS16LSB;
-        break;
-    case AUDIO_U16LSB:
-        aulib::log::debugLn("U16LSB");
-        Stream_priv::fSampleConverter = Aulib::floatToU16LSB;
-        break;
-    case AUDIO_S16MSB:
-        aulib::log::debugLn("S16MSB");
-        Stream_priv::fSampleConverter = Aulib::floatToS16MSB;
-        break;
-    case AUDIO_U16MSB:
-        aulib::log::debugLn("U16MSB");
-        Stream_priv::fSampleConverter = Aulib::floatToU16MSB;
-        break;
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-    case AUDIO_S32LSB:
-        aulib::log::debugLn("S32LSB");
-        Stream_priv::fSampleConverter = Aulib::floatToS32LSB;
-        break;
-    case AUDIO_S32MSB:
-        aulib::log::debugLn("S32MSB");
-        Stream_priv::fSampleConverter = Aulib::floatToS32MSB;
-        break;
-    case AUDIO_F32LSB:
-        aulib::log::debugLn("F32LSB");
-        Stream_priv::fSampleConverter = Aulib::floatToFloatLSB;
-        break;
-    case AUDIO_F32MSB:
-        aulib::log::debugLn("F32MSB");
-        Stream_priv::fSampleConverter = Aulib::floatToFloatMSB;
-        break;
-#endif
-    default:
-        aulib::log::warnLn("Unknown audio format spec: {}", Stream_priv::fAudioSpec.format);
+    }
+    if (!sampleConverterFound) {
+        aulib::log::warnLn("Unknown audio format spec: {}", Stream_priv_device::fAudioSpec.format);
         Aulib::quit();
         return false;
     }
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-    SDL_PauseAudioDevice(Stream_priv::fDeviceId, false);
+    SDL_PauseAudioDevice(Stream_priv_device::fDeviceId, false);
 #else
     SDL_PauseAudio(/*pause_on=*/0);
 #endif
@@ -133,8 +205,8 @@ auto Aulib::initWithoutOutput(const int freq, const int channels) -> bool
         return false;
     }
 
-    Stream_priv::fAudioSpec.freq = freq;
-    Stream_priv::fAudioSpec.channels = channels;
+    Stream_priv_device::fAudioSpec.freq = freq;
+    Stream_priv_device::fAudioSpec.channels = channels;
     gInitType = InitType::NoOutput;
     std::atexit(Aulib::quit);
     return true;
@@ -146,33 +218,40 @@ void Aulib::quit()
         return;
     }
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-    SDL_CloseAudioDevice(Stream_priv::fDeviceId);
+    SDL_CloseAudioDevice(Stream_priv_device::fDeviceId);
 #else
     SDL_CloseAudio();
 #endif
     SDL_QuitSubSystem(SDL_INIT_AUDIO);
-    Stream_priv::fSampleConverter = nullptr;
+    switch (Stream_priv_device::fDataType) {
+    case BufferDataType::FLOAT:
+        Stream_priv<float>::fSampleConverter = nullptr;
+        break;
+    case BufferDataType::INT32:
+        Stream_priv<int32_t>::fSampleConverter = nullptr;
+        break;
+    }
     gInitType = InitType::None;
 }
 
 auto Aulib::sampleFormat() noexcept -> AudioFormat
 {
-    return Stream_priv::fAudioSpec.format;
+    return Stream_priv_device::fAudioSpec.format;
 }
 
 auto Aulib::sampleRate() noexcept -> int
 {
-    return Stream_priv::fAudioSpec.freq;
+    return Stream_priv_device::fAudioSpec.freq;
 }
 
 auto Aulib::channelCount() noexcept -> int
 {
-    return Stream_priv::fAudioSpec.channels;
+    return Stream_priv_device::fAudioSpec.channels;
 }
 
 auto Aulib::frameSize() noexcept -> int
 {
-    return Stream_priv::fAudioSpec.samples;
+    return Stream_priv_device::fAudioSpec.samples;
 }
 
 /*

--- a/src/sampleconv.h
+++ b/src/sampleconv.h
@@ -20,6 +20,17 @@ AULIB_NO_EXPORT void floatToS32MSB(Uint8 dst[], const Buffer<float>& src) noexce
 AULIB_NO_EXPORT void floatToFloatLSB(Uint8 dst[], const Buffer<float>& src) noexcept;
 AULIB_NO_EXPORT void floatToFloatMSB(Uint8 dst[], const Buffer<float>& src) noexcept;
 
+AULIB_NO_EXPORT void int32ToS8(Uint8 dst[], const Buffer<int32_t>& src) noexcept;
+AULIB_NO_EXPORT void int32ToU8(Uint8 dst[], const Buffer<int32_t>& src) noexcept;
+AULIB_NO_EXPORT void int32ToS16LSB(Uint8 dst[], const Buffer<int32_t>& src) noexcept;
+AULIB_NO_EXPORT void int32ToU16LSB(Uint8 dst[], const Buffer<int32_t>& src) noexcept;
+AULIB_NO_EXPORT void int32ToS16MSB(Uint8 dst[], const Buffer<int32_t>& src) noexcept;
+AULIB_NO_EXPORT void int32ToU16MSB(Uint8 dst[], const Buffer<int32_t>& src) noexcept;
+AULIB_NO_EXPORT void int32ToS32LSB(Uint8 dst[], const Buffer<int32_t>& src) noexcept;
+AULIB_NO_EXPORT void int32ToS32MSB(Uint8 dst[], const Buffer<int32_t>& src) noexcept;
+AULIB_NO_EXPORT void int32ToFloatLSB(Uint8 dst[], const Buffer<int32_t>& src) noexcept;
+AULIB_NO_EXPORT void int32ToFloatMSB(Uint8 dst[], const Buffer<int32_t>& src) noexcept;
+
 } // namespace Aulib
 
 /*


### PR DESCRIPTION
This is an attempt at #40

There may be a much better way to do this.

Hopefully some of the code here, such as sampleconv, can be reused in another approach to adding int32_t buffer support.