### PR TITLE
Revert "Log Stream rwops errors and prevent opening Stream if null"

### DIFF
--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -18,19 +18,11 @@
 Aulib::Stream::Stream(const std::string& filename, std::unique_ptr<Decoder> decoder,
                       std::unique_ptr<Resampler> resampler)
     : Stream(SDL_RWFromFile(filename.c_str(), "rb"), std::move(decoder), std::move(resampler), true)
-{
-    if (not d->fRWops) {
-        aulib::log::warnLn("Stream failed to create rwops: {}", SDL_GetError());
-    }
-}
+{}
 
 Aulib::Stream::Stream(const std::string& filename, std::unique_ptr<Decoder> decoder)
     : Stream(SDL_RWFromFile(filename.c_str(), "rb"), std::move(decoder), true)
-{
-    if (not d->fRWops) {
-        aulib::log::warnLn("Stream failed to create rwops: {}", SDL_GetError());
-    }
-}
+{}
 
 Aulib::Stream::Stream(SDL_RWops* rwops, std::unique_ptr<Decoder> decoder,
                       std::unique_ptr<Resampler> resampler, bool closeRw)
@@ -55,10 +47,6 @@ auto Aulib::Stream::open() -> bool
 
     if (d->fIsOpen) {
         return true;
-    }
-    if (not d->fRWops) {
-        SDL_SetError("Cannot open stream: null rwops.");
-        return false;
     }
     if (not d->fDecoder->open(d->fRWops)) {
         return false;


### PR DESCRIPTION
This reverts commit b2df2dfeddc692caa01fd1e1769f59b285912b87.

Custom decoders do not always use `rwops`, so this check was incorrect.
For example, we have a `PushAulibDecoder` that doesn't use rwops: https://github.com/diasurgical/DevilutionX/blob/master/Source/utils/push_aulib_decoder.h

Fixes #44